### PR TITLE
Fix pagination

### DIFF
--- a/frontend/src/pages/Chat/Components/ListOfAllThreads.js
+++ b/frontend/src/pages/Chat/Components/ListOfAllThreads.js
@@ -252,10 +252,10 @@ const ListOfAllThreads = ({ posts, pagination, onPageChange }) => {
 
       {pagination && pagination.pages > 1 && (
         <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
-          <Pagination 
-            count={pagination.pages} 
-            page={pagination.page} 
-            onChange={(e, page) => onPageChange(page)}
+          <Pagination
+            count={pagination.pages}
+            page={pagination.page}
+            onChange={onPageChange}
             color="primary"
             size={isMobile ? "small" : "medium"}
           />


### PR DESCRIPTION
## Summary
- fix onPageChange handler in chat thread list so Pagination passes both args

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fb508424832fb15186d99aeefcdc